### PR TITLE
Align Frida tracer output with Tenet text format

### DIFF
--- a/tracer/frida/README.md
+++ b/tracer/frida/README.md
@@ -1,0 +1,28 @@
+# Frida tracer for Tenet
+
+This tracer is adapted from [Synacktiv's Frinet project](https://github.com/synacktiv/frinet) so it can emit text traces that match the Tenet format used by this repository. It hooks a function entry with Frida's Stalker and writes the trace to `tracer/frida/traces/`.
+
+## Requirements
+- Python 3
+- [Frida](https://frida.re/) (installable with `pip install frida`)
+
+## Usage
+Run `trace.py` from this directory. The interface mirrors the upstream Frinet tool:
+
+```bash
+python3 trace.py spawn <binary_or_package> <module_name> <function_address> [options]
+python3 trace.py attach <process_or_pid> <module_name> <function_address> [options]
+```
+
+Common options:
+- `-a/--args` to pass comma-separated arguments when spawning (for example `"/bin/ls,-la"`).
+- `-m/--multirun` to keep the hook active for multiple executions.
+- `-e/--exclude` to exclude other modules from stalking (faster but memory tracing may be inaccurate).
+- `-s/--slow` to use the multi-architecture JavaScript tracer when x86/ARMv7 support is required.
+- `-E/--end` to stop at a specific end address instead of the function return.
+
+The tracer will create files named like `<process>_<epoch>_<tid>.log` inside `tracer/frida/traces/`. Each new trace begins with a base comment such as `# SO: libfoo.so @ 0x1234000`, matching the Tenet text trace expectations (`demo/log.txt`).
+
+## Notes
+- Fast mode supports `arm64` and `x64`; other architectures fall back to the slower JavaScript implementation.
+- Module map summaries are written when tracing every module using `--traced-module '*'`.

--- a/tracer/frida/slow/trace_slow.js
+++ b/tracer/frida/slow/trace_slow.js
@@ -1,0 +1,222 @@
+(binbase, binend, arch, END_ADDR, swap_rw)=>
+{
+class Slowmode
+{
+    FLUSH_THRESHOLD = 8000;
+    allctx = []
+    regs = []
+    lastwrite = null
+    nomem = []
+    realcontext
+
+    constructor(arch) {
+        this.nomem = new Set()
+        if(arch=="arm64")
+        {
+            for(let i=0;i<29;i++)this.regs.push("x"+i)
+            this.regs.push("fp")
+            this.regs.push("sp")
+            this.regs.push("lr")
+            this.regs.push("pc")
+            this.realcontext = (c,r)=>this.realcontext_arm64(c,r)
+        }
+        else if(arch=="arm")
+        {
+            for(let i=0;i<13;i++)this.regs.push("r"+i)
+            this.regs.push("sp")
+            this.regs.push("lr")
+            this.regs.push("pc")
+            this.realcontext = (c,r)=>this.realcontext_arm(c,r)
+        }
+        else if(arch=="x64")
+        {
+            this.regs.push("rax")
+            this.regs.push("rbx")
+            this.regs.push("rcx")
+            this.regs.push("rdx")
+            this.regs.push("rbp")
+            this.regs.push("rsp")
+            this.regs.push("rsi")
+            this.regs.push("rdi")
+            for(let i=8;i<16;i++)this.regs.push("r"+i)
+            this.regs.push("rip")
+
+            this.realcontext = (c,r)=>this.realcontext_x64(c,r)
+
+            this.nomem.add("lea")
+            this.nomem.add("nop")
+        }
+        else if(arch=="ia32")
+        {
+            this.regs.push("eax")
+            this.regs.push("ebx")
+            this.regs.push("ecx")
+            this.regs.push("edx")
+            this.regs.push("ebp")
+            this.regs.push("esp")
+            this.regs.push("esi")
+            this.regs.push("edi")
+            this.regs.push("eip")
+
+            this.realcontext = (c,r)=>this.realcontext_x86(c,r)
+
+            this.nomem.add("lea")
+            this.nomem.add("nop")
+        }
+        this.op_access = "w"
+        if(swap_rw)this.op_access = "r"
+
+    }
+    
+    //var instrs = INSTRSJSON
+    
+    buf2hex(buffer) {
+        var u = new Uint8Array(buffer),
+            a = new Array(u.length),
+            i = u.length;
+        while (i--) // map to hex
+            a[i] = (u[i] < 16 ? '0' : '') + u[i].toString(16);
+        u = null; // free memory
+        return a.join('');
+    };
+
+    realcontext_x86(context, r)
+    {
+        if(context[r])return context[r]
+        else send("CONTEXT MISMATCH : "+r)
+    }
+
+    realcontext_x64(context, r)
+    {
+        if(context[r])return context[r]
+        else send("CONTEXT MISMATCH : "+r)
+    }
+
+    realcontext_arm64(context, r)
+    {
+        if(context[r])return context[r]
+        let r2 = 'x'+r.substr(1)
+        if(context[r2])return context[r2]
+        else send("CONTEXT MISMATCH : "+r2)
+
+    }
+    
+    regtranslate_arm = {"fp":"r11","ip":"r12"}
+    realcontext_arm(context, r)
+    {
+        if(context[r])return context[r]
+        let r2 = this.regtranslate_arm[r]
+        if(context[r2])return context[r2]
+        else send("CONTEXT MISMATCH : "+r)
+
+    }
+    
+    testcb(context, readval, writeval)
+    {   
+        let addr = context.pc.sub(binbase)
+    
+        let contx = {}
+        for(let reg of this.regs)
+        {
+            contx[reg] = this.realcontext(context, reg)
+        }
+        
+        if(this.lastwrite)
+        {
+            contx.mw = this.lastwrite.ptr+":"+this.buf2hex(this.lastwrite.ptr.readByteArray(this.lastwrite.siz))
+            this.lastwrite=null
+        }
+        if(writeval)
+        {
+            try{
+                this.lastwrite={}
+                let siz = 8
+                
+                let ptr = (new NativePointer(this.realcontext(context, writeval[0].base))).add(writeval[0].disp)
+                if(writeval[0].index)ptr = ptr.add(new NativePointer(this.realcontext(context, writeval[0].index)))
+                this.lastwrite.ptr = ptr
+                this.lastwrite.siz = siz
+            }
+            catch(e)
+            {
+                send("minor error : mw failed !")
+            }
+        }
+    
+        if(readval)
+        {
+            try{
+                let siz = 8
+                let ptr = (new NativePointer(this.realcontext(context, readval[0].base))).add(readval[0].disp)
+                if(readval[0].index)
+                {
+                    let dst = this.realcontext(context, readval[0].index)
+                    
+                    ptr = ptr.add(new NativePointer(dst))
+                }
+                contx.mr = ptr+":"+this.buf2hex(ptr.readByteArray(siz))
+            }
+            catch(e)
+            {
+                send("minor error : mr failed !")
+            }
+        }
+    
+        this.allctx.push(contx)
+    
+        if(this.allctx.length>=this.FLUSH_THRESHOLD)flush()
+        if(END_ADDR && addr.toInt32() == END_ADDR)
+        {
+            send("Reached end address !")
+            flush()
+            send("SENT "+this.allctx.length)
+            Stalker.unfollow(Process.getCurrentThreadId());
+            Stalker.flush()
+        }
+    }
+
+    flush()
+    {
+        send(this.allctx)
+        this.allctx = []
+    }
+    
+    transform(iterator)
+    {
+        let instruction = iterator.next()
+        let self = this
+        do{
+            if(instruction.address < binend && instruction.address >= binbase)
+            {
+                let read = null;
+                let write = null;
+                for(let op of instruction.operands)
+                {
+                    if(op.type=="mem" && op.value.base && !this.nomem.has(instruction.mnemonic))
+                    {
+                        if(op.access==this.op_access)
+                        {
+                            write = [op.value, instruction.mnemonic, instruction.opStr]
+                        }
+                        else
+                        {
+                            read = [op.value, instruction.mnemonic, instruction.opStr]
+                        }
+                    }
+                }
+                iterator.putCallout(function(context)
+                {
+                    self.testcb(context,read,write)
+                });
+            }
+            iterator.keep();
+            
+            
+        } while ((instruction = iterator.next()) !== null)
+    
+    }
+    
+    
+}
+return new Slowmode(arch)
+}

--- a/tracer/frida/slow/trace_slow.py
+++ b/tracer/frida/slow/trace_slow.py
@@ -1,0 +1,63 @@
+import logging
+regs = []
+
+def init_regs(arch):
+    if len(regs):return
+    if arch == "arm64":
+        for i in range(29):
+            regs.append("x"+str(i))
+        regs.append("fp")
+        regs.append("sp")
+        regs.append("lr")
+        regs.append("pc")
+    elif arch == "arm":
+        for i in range(13):
+            regs.append("r"+str(i))
+        regs.append("sp")
+        regs.append("lr")
+        regs.append("pc")
+    elif arch == "x64":
+        regs.append("rax")
+        regs.append("rbx")
+        regs.append("rcx")
+        regs.append("rdx")
+        regs.append("rbp")
+        regs.append("rsp")
+        regs.append("rsi")
+        regs.append("rdi")
+        for i in range(8,16):
+            regs.append("r"+str(i))
+        regs.append("rip")
+    elif arch == "ia32":
+        regs.append("eax")
+        regs.append("ebx")
+        regs.append("ecx")
+        regs.append("edx")
+        regs.append("ebp")
+        regs.append("esp")
+        regs.append("esi")
+        regs.append("edi")
+        regs.append("eip")
+    else:
+        logging.error("No such arch !")
+        exit(1)
+
+def do_slowmode_output(payload, arch):
+    init_regs(arch)
+
+    lastctx = None
+    lines = []
+    for ctx in payload:
+        line = []
+        for k in regs:
+            if k in ctx and (not lastctx or not k in lastctx or lastctx[k]!=ctx[k]):
+                line.append(k+"="+ctx[k])
+        
+        for k in ["mw", "mr"]:
+            if not k in ctx:continue
+            addr,val = ctx[k].split(":")
+            line.append(k+"="+addr+":"+val)
+        
+        lastctx=ctx
+        lines.append(",".join(line))
+    return {'id':'trace', 'tid':0, 'data':"\n".join(lines)+"\n"}

--- a/tracer/frida/trace.js
+++ b/tracer/frida/trace.js
@@ -1,0 +1,205 @@
+var c_src;
+var js_src;
+var threadIds = []
+var flushs = [];
+
+function sendSrc(args) {
+        if(args["is_c"])c_src = args["src"];
+        else js_src = args["src"];
+}
+
+function removeItemOnce(arr, value) {
+        var index = arr.indexOf(value);
+        if (index > -1) {
+                arr.splice(index, 1);
+        }
+        return arr;
+}
+
+
+function trace(args) {
+        var module = args["module"];
+        var traced_module = args["traced_module"];
+
+        var addr = ptr(args["addr"]);
+        var once = args["once"];
+        var exclude = args["exclude"];
+        var needmem = args["needmem"];
+
+        var traced_base = traced_module == '*'? 0: -1;
+        var traced_end = traced_module == '*'? Infinity: -1;
+        var base = -1;
+        var modules = Process.enumerateModules();
+        modules.forEach(mod => {
+
+                if(traced_module == '*')
+                {
+                        send({id: "module", name: mod.name,start: mod.base, end: mod.base.add(mod.size)});
+                }
+                else if (mod.name !== traced_module) {
+                        if(exclude)
+                        {
+                                console.log(`Excluding '${mod.name}'.`);
+
+                                // We're only interested in stalking our code
+                                Stalker.exclude({
+                                "base": mod.base,
+                                "size": mod.size,
+                                });
+                        }
+                }
+                else if(traced_base == -1)
+                {
+                        traced_base = mod.base
+                        traced_end = mod.base.add(mod.size);
+                }
+
+                if ((mod.name == module)) {
+                        if(base != -1)
+                                console.log("WARNING : The same module name is present twice ! ("+base+" vs "+mod.base+"). Keeping the first one...")
+                        else base = mod.base;
+                }
+        });
+
+        if ((base < 0) || (traced_base < 0) || (traced_end < 0)) {
+                console.error(`Unable to find module. Module list :`);
+                modules.forEach(mod => {console.log(mod.name)})
+                return 1;
+        }
+
+        send({id: "module_base", module: module, base: base.toString()});
+        if(traced_module != '*')send({id: "slide", slide: traced_base});
+        
+        var slow = args.slow
+        var cmods = []
+        var getstalker = (mytid) => {
+                var transform
+                
+                var flush
+                if(slow)
+                {
+                        //const mod = new Module(js_src)
+                        var SlowMode = eval(js_src)(traced_base, traced_end, Process.arch, args.end_addr, args["swap_rw"])
+                        transform = (iterator)=>SlowMode.transform(iterator)
+                        flush = ()=>SlowMode.flush()
+                }
+                else
+                {
+                        if(args.end_addr) //Ensure flushing on end address
+                        {
+                                c_src = "#define END_ADDR "+(traced_base.add(args.end_addr))+"LL\n"+c_src
+                        }
+                        if(args.trace_addr) //Ensure flushing on trace address
+                        {
+                                c_src = "#define TRACE_ADDR "+(traced_base.add(args.trace_addr))+"LL\n"+c_src
+                        }
+
+                        let filter_func
+                        if(traced_module == '*')
+                                filter_func = new NativeCallback(addr => {
+                                        return 0;
+                                }, 'int', ['size_t'])
+                        else
+                                filter_func = new NativeCallback(addr => {
+                                        return ((addr >= traced_base) && (addr < traced_end)) ? 0 : 1;
+                                }, 'int', ['size_t'])
+
+                        let cmod = new CModule(c_src, {
+                                'state': Memory.alloc(Process.pointerSize),
+                                'filter': filter_func,
+                                'exclude': new NativeCallback(() => {
+                                        return exclude ? 1 : 0;
+                                }, 'bool', []),
+                                'needmem': new NativeCallback(() => {
+                                        return needmem ? 1 : 0;
+                                }, 'bool', []),
+                                'swap_rw': new NativeCallback(() => {
+                                        return args["swap_rw"];
+                                }, 'char', []),
+                                'send': new NativeCallback(ptr => {
+                                        var cstr = ptr.readCString();
+                                        send({
+                                                id: "trace",
+                                                tid: mytid,
+                                                data: cstr,
+                                        });
+                                }, 'void', ['pointer']),
+                                'send_end': new NativeCallback(() => {
+                                        Stalker.unfollow(this.threadId);
+                                        Stalker.flush();
+                                        flush()
+                                        Stalker.garbageCollect();
+                                }, 'void', []),
+                        });
+                        cmods.push(cmod)
+                        transform = cmod.transform
+                        flush = new NativeFunction(cmod.flush, 'void', []);
+                }
+                
+                return [flush, transform]
+        }
+        
+        Process.setExceptionHandler(function (details) {
+                console.log(`Got exception : flushing Stalker`);
+                Stalker.flush();
+                for(let flush of flushs)
+                        flush()
+        })
+
+        var hook
+        var filter_tid = -1
+        var onEnter = function(args) {
+                this.inside = false
+                let curpid = Process.getCurrentThreadId()
+                if(threadIds.includes(curpid) || (filter_tid>=0 && filter_tid != curpid))return
+                this.inside = true
+                console.log(`Entering function`);
+                threadIds.push(curpid)
+                let stalk = getstalker(curpid)
+                this.flush = stalk[0]
+                flushs.push(this.flush)
+                Stalker.follow(curpid, {transform: stalk[1]});
+        }
+        var onLeave = function(retval) {
+                if(!this.inside || (args.end_addr != undefined))return
+                removeItemOnce(threadIds, Process.getCurrentThreadId())
+                console.log(`Leaving function`);
+                removeItemOnce(flushs, this.flush)
+                Stalker.unfollow(Process.getCurrentThreadId());
+                Stalker.flush();
+                this.flush()
+                if (once) {
+                        Stalker.garbageCollect();
+                        hook.detach();
+                }
+        }
+
+        hook = Interceptor.attach(base.add(addr), {
+                onEnter: onEnter,
+                onLeave: onLeave,
+        });
+
+        return 0;
+}
+
+function end()
+{       
+        for(let t of threadIds)
+        {
+                Stalker.unfollow(t);
+        }
+        Stalker.flush();
+}
+
+function arch()
+{       
+        return Process.arch
+}
+
+rpc.exports = {
+        sendSrc: sendSrc,
+        trace: trace,
+        end: end,
+        arch: arch
+}
+

--- a/tracer/frida/trace.py
+++ b/tracer/frida/trace.py
@@ -1,0 +1,389 @@
+#!/bin/env python3
+
+import re
+import argparse
+import logging
+import os
+import sys
+import time
+import pathlib
+import frida
+from slow.trace_slow import do_slowmode_output
+from utils import print_lib_usage
+
+wd = os.path.dirname(os.path.abspath(__file__))
+MODULE_JS_PATH = os.path.join(wd,'trace.js')
+MODULE_C_X64_PATH = os.path.join(wd,'trace_x64.c')
+MODULE_C_ARM64_PATH = os.path.join(wd,'trace_arm64.c')
+MODULE_C_ARM_PATH = os.path.join(wd,'trace_arm.c')
+MODULE_JS_SLOW_PATH = os.path.join(wd,'slow','trace_slow.js')
+TRACES_DIR = os.path.join(wd,"traces")
+
+pathlib.Path(TRACES_DIR).mkdir(exist_ok=True)
+
+def file_read(path: str) -> str:
+    root_dir = os.path.dirname(os.path.realpath(__file__))
+    with open(os.path.join(root_dir, path), 'r') as fd:
+        return fd.read()
+
+
+last_modules = None
+last_trace = None
+def file_append(path: str, data: str, is_modules: bool):
+    global last_modules, last_trace
+    root_dir = os.path.dirname(os.path.realpath(__file__))
+    filepath = os.path.join(root_dir, path)
+    if not os.path.isfile(filepath):
+        logging.info("Creating file "+filepath)
+
+    if is_modules:
+        last_modules = filepath
+    else:
+        last_trace = filepath
+
+    with open(filepath, 'a') as fd:
+        return fd.write(data)
+
+
+def do_spawn(args):
+    do_trace(args, False)
+
+def do_attach(args):
+    do_trace(args, True)
+
+def do_trace(args, attach):
+    global arch, slide
+    devmgr = frida.get_device_manager()
+
+    if args.device:
+        logging.info('Connecting to device...')
+        try:
+            dev = devmgr.get_device(args.device)
+        except frida.InvalidArgumentError as exc:
+            logging.error(f'Cannot connect to device: `{exc}`.')
+            return 1
+    elif args.remote or args.host:
+        host = args.host
+        if args.host is None:
+            host = '127.0.0.1:27042'
+            logging.warning(f'Host is not defined... using {host!r}.')
+
+        logging.info('Adding remote device...')
+        dev = devmgr.add_remote_device(host)
+    elif args.usb:
+        logging.info('Connecting to USB device...')
+        try:
+            dev = devmgr.get_usb_device()
+        except frida.InvalidArgumentError as exc:
+            logging.error(f'Cannot connect to USB device: `{exc}`.')
+            return 1
+    else:
+        logging.info('Using local device')
+        dev = devmgr.get_local_device()
+    try:
+        sysenv = dev.query_system_parameters()
+        logging.debug(f'sysenv: {sysenv}')
+        logging.info(f'''Connected to device ({sysenv['arch']} {sysenv['platform']} {sysenv['os']['name']} {sysenv['os']['version']}).''')
+
+        process = args.process
+        procname = process
+
+        if attach :
+            if process.isnumeric():
+                process = int(process)
+                logging.info(f'Attaching to PID {process}...')
+            else:
+                logging.info(f'Attaching to process name {process!r}...')
+        else:
+            def on_output(pid, fd, data):
+                if 0 < fd < 3:
+                    prefix = "STDOUT"
+                    if fd==2:
+                        prefix = "STDERR"
+                    try:print(prefix+" : "+data.decode().replace("\n", f"\n{prefix} : "))
+                    except:print(prefix+" : "+repr(data))
+            dev.on("output", on_output)
+            argv = None
+            if args.args:
+                argv = args.args.split(",")
+            procname = process.split("/")[-1]
+            process = int(dev.spawn(process, argv=argv, env={}, cwd=None, stdio="pipe"))
+            logging.info("Spawning process ")
+        sess = dev.attach(process)
+
+        # TODO: refactor + cleanup...
+        epoch = str(int(time.time()))
+        slide = None # ASLR slide
+        module_base = None
+        module_name = args.module
+        seen_tids = set() # seen thread IDs
+        midline_break = {}
+        logging.info('Loading JS module...')
+        script = sess.create_script(file_read(MODULE_JS_PATH))
+        def on_message(msg, data):
+            global slide
+            logging.debug(f'message: {msg}')
+
+            if msg['type'] == 'error':
+                # TODO: handle errors
+                raise Exception(f'Script error: `{msg["description"]}`')
+            elif msg['type'] == 'send':
+                payload = msg['payload']
+
+                if isinstance(payload, str): #Slow mode
+                    logging.info("JS | "+payload)
+                    return
+
+                if isinstance(payload, list): #Slow mode
+                    payload = do_slowmode_output(payload, arch)
+
+                if payload['id'] == 'slide':
+                    slide = int(payload['slide'], 0)
+                    logging.info(f'Received ASLR slide: 0x{slide:x}.')
+                    return
+                elif payload['id'] == 'module_base':
+                    module_base = int(payload['base'], 0)
+                    module_name = payload.get('module', module_name)
+                    logging.info(f"Tracing module {module_name} at 0x{module_base:x}.")
+                    return
+                elif payload['id'] == 'trace':
+                    tid = payload['tid']
+                    data = payload['data']
+                    if not data:
+                        return
+                    if tid in midline_break and midline_break[tid]: #Not very nice but works
+                        newline_idx = data.find("\n")
+                        data = data[:newline_idx]+re.sub("^,","",data[newline_idx:],flags=re.M)
+                    else:
+                        data = re.sub("^,","",data,flags=re.M)
+                    path = f'{TRACES_DIR}/'+re.sub("[^a-zA-Z_0-9.]","",f'{procname}_{epoch}_{tid}.log')
+                    # TODO: refactor + cleanup...
+                    if not tid in seen_tids:
+                        logging.info(f'Received trace data for new thread {tid}.')
+                        header = ""
+                        if module_base is not None:
+                            header += f'# SO: {module_name} @ 0x{module_base:x}\n'
+                        else:
+                            logging.warning('Module base not received yet, skipping base comment header.')
+                        data = header + data
+                        seen_tids.add(tid)
+                    midline_break[tid] = data[-1]!="\n"
+                    logging.info(f'Writing trace data of {len(data)} bytes...')
+                    file_append(path, data, False)
+                    return
+                elif payload['id'] == 'module':
+                    path = f'{TRACES_DIR}/'+re.sub("[^a-zA-Z_0-9.]","",f'{procname}_{epoch}.modules')
+                    data = payload["name"] + " " + payload['start'] + " " + payload['end'] + "\n"
+                    file_append(path, data, True)
+
+
+        script.on('message', on_message)
+        script.load()
+
+        arch = script.exports_sync.arch()
+        if arch != 'arm64' and arch != "arm" and arch != "x64" and arch != "ia32":
+            logging.error(f'Process architecture {arch} is not supported.')
+            return 1
+
+        elif arch!="arm64" and arch!='x64' and not args.slow:
+            logging.warning(f'Process architecture {arch} is only supported in slow mode.\n Slow mode has been activated.')
+            args.slow = True
+        
+        if args.slow and not args.exclude:
+            logging.warning("The exclude option was activated because it is required for slow mode")
+            args.exclude = True
+
+        if args.slow and args.nomem:
+            logging.warning(f'nomem is incompatible with slow mode, it will have no effect')
+
+        logging.info('Loading C module...')
+        if arch == 'x64':
+            c_path = MODULE_C_X64_PATH
+        if arch == 'arm64':
+            c_path = MODULE_C_ARM64_PATH
+        js_path = MODULE_JS_SLOW_PATH
+
+        if args.slow:
+            js_src = file_read(js_path)
+            script.exports_sync.send_src({'src': js_src, 'is_c':False})
+        else:
+            c_src = file_read(c_path)
+            script.exports_sync.send_src({'src': c_src, 'is_c':True})
+        
+        try:
+            addr = int(args.addr, 0)
+        except ValueError:
+            logging.error('Invalid address.')
+            return 1
+
+        logging.info('Tracing...')
+        errcode = script.exports_sync.trace({
+            'module': args.module,
+            'traced_module' : args.traced_module if args.traced_module else args.module,
+            'addr': addr,
+            'once': not args.multirun,
+            'exclude' : args.exclude,
+            'needmem' : not args.nomem,
+            'swap_rw' : 1 if (arch == "arm64" and sysenv['os']['name']=="Android") else 0,
+            'slow' : args.slow,
+            'end_addr' : int(args.end,16) if args.end else None,
+            'trace_addr' : int(args.flushaddr,16) if args.flushaddr else None
+        })
+        logging.debug(f'errcode: {errcode}')
+
+        if errcode != 0:
+            logging.error('Something went wrong.')
+            return 1
+
+        if not attach:
+            dev.resume(process)
+
+        logging.info("CTRL+C to interrupt trace")
+        try:
+            sys.stdin.read()
+        except KeyboardInterrupt:
+            logging.info('Interrupting...')
+
+        if args.traced_module == "*" and last_modules and last_trace: 
+            print_lib_usage(last_trace, last_modules)
+
+        script.exports_sync.end()
+        script.unload()
+        sess.detach()
+    except frida.ServerNotRunningError as exc:
+        logging.error(f'Cannot connect to remote frida server: `{exc}`.')
+        return 1
+    except frida.ProcessNotFoundError as exc:
+        logging.error(f'Unable to find process: `{exc}`.')
+        return 1
+    except frida.TransportError as exc:
+        logging.critical(f'Connection to remote frida server closed: `{exc}`.')
+        return 1
+    except frida.ProcessNotRespondingError as exc:
+        logging.critical(f'Process is not responding: `{exc}`.')
+        return 1
+    except frida.InvalidOperationError as exc:
+        logging.critical(f'Aw, Snap! Something went wrong: `{exc}`.')
+        return 1
+
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser('Tenet Frida Tracer')
+
+    parser.add_argument(
+        '-v', '--verbose',
+        action='store_true',
+        help='verbose output'
+    )
+
+    parser.add_argument(
+        '-D', '--device',
+        type=str,
+        help='connect to device with the given ID',
+    )
+
+    parser.add_argument(
+        '-U', '--usb',
+        action='store_true',
+        help='connect to USB device',
+    )
+
+    parser.add_argument(
+        '-R', '--remote',
+        action='store_true',
+        help='connect to remote frida server'
+    )
+
+    parser.add_argument(
+        '-H', '--host',
+        type=str,
+        help='connect to remote frida server on host'
+    )
+
+    parser.add_argument(
+        '-m', '--multirun',
+        action='store_true',
+        help='do not unhook after first execution'
+    )
+
+    parser.add_argument(
+        '-a', '--args',
+        type=str,
+        help='comma-separated argument list for spawn (including binary name) : "/bin/sh,-c,ls"'
+    )
+
+    parser.add_argument(
+        '-e', '--exclude',
+        action='store_true',
+        help='exclude all other modules (memory tracing will be inaccurate)'
+    )
+
+    parser.add_argument(
+        '-n', '--nomem',
+        action='store_true',
+        help='disable memory tracking, makes tracing a bit faster and can fix some issues'
+    )
+
+    parser.add_argument(
+        '-s', '--slow',
+        action='store_true',
+        help='use slower JS implementation (multiarch)'
+    )
+
+    parser.add_argument(
+        '-E', '--end',
+        type=str,
+        help='specify end address instead of function exit (-1 to never end)'
+    )
+
+    parser.add_argument(
+        '-F', '--flushaddr',
+        type=str,
+        help='Address of instruction that will force a trace flush (useful when investigating a crash)'
+    )
+
+    parser.add_argument(
+        '-t', '--traced-module',
+        type=str,
+        help="Module name to trace PC from, equal to module argument by default, '*' for ALL modules. '*' will also create a file containing the module map, and summarize which libs were present in the trace"
+    )
+
+    sp = parser.add_subparsers()
+    sp_spawn = sp.add_parser('spawn', help='Spawn process')
+    sp_attach = sp.add_parser('attach', help='Attach to process')
+
+    parser.add_argument(
+        'process',
+        type=str,
+        help='attach:[process name or PID]; spawn:[binary path or package name]'
+    )
+
+    parser.add_argument(
+        'module',
+        type=str,
+        help='module name to place the hook'
+    )
+
+    parser.add_argument(
+        'addr',
+        type=str,
+        help='entrypoint function address'
+    )
+
+    sp_spawn.set_defaults(func=do_spawn)
+    sp_attach.set_defaults(func=do_attach)
+
+    args = parser.parse_args()
+
+    logging.basicConfig(format='%(asctime)s %(levelname)8s | %(message)s',
+        level=logging.DEBUG if args.verbose else logging.INFO)
+
+    return args.func(args)
+
+
+if __name__ == '__main__':
+    errcode = main()
+    sys.exit(errcode)
+

--- a/tracer/frida/trace_arm64.c
+++ b/tracer/frida/trace_arm64.c
@@ -1,0 +1,709 @@
+#include <capstone.h>
+#include <glib.h>
+#include <gum/gumstalker.h>
+#include <string.h>
+
+
+#define TRACE_FLUSH_SIZE        (1 << 20)
+
+#define CTX_INSN_REGS_MAX       32
+#define CTX_INSN_MEMS_MAX       1
+
+
+struct ctx_insn_mem {
+        arm64_op_mem    op;     /* operand */
+        cs_ac_type      ac;     /* access type */
+        gsize           size;   /* access size */
+        const guint8    *ptr;   /* resolved pointer */
+};
+
+struct ctx_insn {
+        arm64_reg               regs[CTX_INSN_REGS_MAX];
+        gsize                   n_regs;
+        struct ctx_insn_mem     mems[CTX_INSN_MEMS_MAX];
+        gsize                   n_mems;
+        char call_instruction;
+        bool enable_regs;
+};
+
+struct ctx_trace {
+        gboolean init;
+        guint64 pc;
+        struct ctx_insn ctx_insn;
+};
+
+struct state {
+        struct ctx_trace last_ctx_trace;
+        GString *trace;
+        GumCpuContext *old_cpu_ctx;
+        guint32 mflag;
+        char dump_all_regs;
+        bool exclude;
+        bool needmem;
+};
+
+
+extern struct state *state;
+extern int filter(guintptr addr);
+extern bool exclude();
+extern bool needmem();
+extern char swap_rw();
+extern void send(gchar *str);
+
+
+void init(void);
+void finalize(void);
+void flush(void);
+void send_end(void);
+void transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
+               gpointer user_data);
+
+
+static gsize
+reg_size(arm64_reg reg)
+{
+        switch (reg) {
+        case ARM64_REG_B0 ... ARM64_REG_B31:
+                return 1;
+        case ARM64_REG_H0 ... ARM64_REG_H31:
+                return 2;
+        case ARM64_REG_W0 ... ARM64_REG_W30:
+                return 4;
+        default:
+                return 8;
+        }
+}
+
+static const gchar *
+reg_name(arm64_reg reg)
+{
+        switch (reg) {
+        case ARM64_REG_SP:
+                return "sp";
+        case ARM64_REG_B0:
+        case ARM64_REG_H0:
+        case ARM64_REG_W0:
+        case ARM64_REG_X0:
+                return "x0";
+        case ARM64_REG_B1:
+        case ARM64_REG_H1:
+        case ARM64_REG_W1:
+        case ARM64_REG_X1:
+                return "x1";
+        case ARM64_REG_B2:
+        case ARM64_REG_H2:
+        case ARM64_REG_W2:
+        case ARM64_REG_X2:
+                return "x2";
+        case ARM64_REG_B3:
+        case ARM64_REG_H3:
+        case ARM64_REG_W3:
+        case ARM64_REG_X3:
+                return "x3";
+        case ARM64_REG_B4:
+        case ARM64_REG_H4:
+        case ARM64_REG_W4:
+        case ARM64_REG_X4:
+                return "x4";
+        case ARM64_REG_B5:
+        case ARM64_REG_H5:
+        case ARM64_REG_W5:
+        case ARM64_REG_X5:
+                return "x5";
+        case ARM64_REG_B6:
+        case ARM64_REG_H6:
+        case ARM64_REG_W6:
+        case ARM64_REG_X6:
+                return "x6";
+        case ARM64_REG_B7:
+        case ARM64_REG_H7:
+        case ARM64_REG_W7:
+        case ARM64_REG_X7:
+                return "x7";
+        case ARM64_REG_B8:
+        case ARM64_REG_H8:
+        case ARM64_REG_W8:
+        case ARM64_REG_X8:
+                return "x8";
+        case ARM64_REG_B9:
+        case ARM64_REG_H9:
+        case ARM64_REG_W9:
+        case ARM64_REG_X9:
+                return "x9";
+        case ARM64_REG_B10:
+        case ARM64_REG_H10:
+        case ARM64_REG_W10:
+        case ARM64_REG_X10:
+                return "x10";
+        case ARM64_REG_B11:
+        case ARM64_REG_H11:
+        case ARM64_REG_W11:
+        case ARM64_REG_X11:
+                return "x11";
+        case ARM64_REG_B12:
+        case ARM64_REG_H12:
+        case ARM64_REG_W12:
+        case ARM64_REG_X12:
+                return "x12";
+        case ARM64_REG_B13:
+        case ARM64_REG_H13:
+        case ARM64_REG_W13:
+        case ARM64_REG_X13:
+                return "x13";
+        case ARM64_REG_B14:
+        case ARM64_REG_H14:
+        case ARM64_REG_W14:
+        case ARM64_REG_X14:
+                return "x14";
+        case ARM64_REG_B15:
+        case ARM64_REG_H15:
+        case ARM64_REG_W15:
+        case ARM64_REG_X15:
+                return "x15";
+        case ARM64_REG_B16:
+        case ARM64_REG_H16:
+        case ARM64_REG_W16:
+        case ARM64_REG_X16:
+                return "x16";
+        case ARM64_REG_B17:
+        case ARM64_REG_H17:
+        case ARM64_REG_W17:
+        case ARM64_REG_X17:
+                return "x17";
+        case ARM64_REG_B18:
+        case ARM64_REG_H18:
+        case ARM64_REG_W18:
+        case ARM64_REG_X18:
+                return "x18";
+        case ARM64_REG_B19:
+        case ARM64_REG_H19:
+        case ARM64_REG_W19:
+        case ARM64_REG_X19:
+                return "x19";
+        case ARM64_REG_B20:
+        case ARM64_REG_H20:
+        case ARM64_REG_W20:
+        case ARM64_REG_X20:
+                return "x20";
+        case ARM64_REG_B21:
+        case ARM64_REG_H21:
+        case ARM64_REG_W21:
+        case ARM64_REG_X21:
+                return "x21";
+        case ARM64_REG_B22:
+        case ARM64_REG_H22:
+        case ARM64_REG_W22:
+        case ARM64_REG_X22:
+                return "x22";
+        case ARM64_REG_B23:
+        case ARM64_REG_H23:
+        case ARM64_REG_W23:
+        case ARM64_REG_X23:
+                return "x23";
+        case ARM64_REG_B24:
+        case ARM64_REG_H24:
+        case ARM64_REG_W24:
+        case ARM64_REG_X24:
+                return "x24";
+        case ARM64_REG_B25:
+        case ARM64_REG_H25:
+        case ARM64_REG_W25:
+        case ARM64_REG_X25:
+                return "x25";
+        case ARM64_REG_B26:
+        case ARM64_REG_H26:
+        case ARM64_REG_W26:
+        case ARM64_REG_X26:
+                return "x26";
+        case ARM64_REG_B27:
+        case ARM64_REG_H27:
+        case ARM64_REG_W27:
+        case ARM64_REG_X27:
+                return "x27";
+        case ARM64_REG_B28:
+        case ARM64_REG_H28:
+        case ARM64_REG_W28:
+        case ARM64_REG_X28:
+                return "x28";
+        case ARM64_REG_FP:
+                return "fp";
+        case ARM64_REG_LR:
+                return "lr";
+        default:
+                return NULL;
+        }
+}
+
+/* from afl++ */
+static gsize
+mem_size(const cs_insn *insn, cs_arm64_op *op)
+{
+        gsize regs;
+        gsize mnemonic_len;
+
+        switch (insn->id) {
+        case ARM64_INS_STP:
+        case ARM64_INS_STXP:
+        case ARM64_INS_STNP:
+        case ARM64_INS_STLXP:
+        case ARM64_INS_LDP:
+        case ARM64_INS_LDXP:
+        case ARM64_INS_LDNP:
+                regs = 2;
+                break;
+        default:
+                regs = 1;
+                break;
+        }
+
+        mnemonic_len = strlen(insn->mnemonic);
+        if (mnemonic_len == 0)
+                return 0;
+
+        char last = insn->mnemonic[mnemonic_len - 1];
+        switch (last) {
+        case 'b':
+                return 1;
+        case 'h':
+                return 2;
+        case 'w':
+                return 4 * regs;
+        }
+
+        if (op->vas != ARM64_VAS_INVALID)
+                return 0;
+
+        if (op->type != ARM64_OP_REG)
+                return 8 * regs;
+
+        switch (op->reg) {
+        case ARM64_REG_W0 ... ARM64_REG_W30:
+        case ARM64_REG_S0 ... ARM64_REG_S31:
+                return 4 * regs;
+        case ARM64_REG_D0 ... ARM64_REG_D31:
+                return 8 * regs;
+        case ARM64_REG_Q0 ... ARM64_REG_Q31:
+                return 16 * regs;
+        default:
+                return 8 * regs;
+        }
+}
+
+static guint64
+ctx_reg_read(const GumCpuContext *ctx, arm64_reg reg)
+{
+        switch (reg) {
+        case ARM64_REG_SP:
+                return ctx->sp;
+        case ARM64_REG_B0:
+        case ARM64_REG_H0:
+        case ARM64_REG_W0:
+        case ARM64_REG_X0:
+                return ctx->x[0];
+        case ARM64_REG_B1:
+        case ARM64_REG_H1:
+        case ARM64_REG_W1:
+        case ARM64_REG_X1:
+                return ctx->x[1];
+        case ARM64_REG_B2:
+        case ARM64_REG_H2:
+        case ARM64_REG_W2:
+        case ARM64_REG_X2:
+                return ctx->x[2];
+        case ARM64_REG_B3:
+        case ARM64_REG_H3:
+        case ARM64_REG_W3:
+        case ARM64_REG_X3:
+                return ctx->x[3];
+        case ARM64_REG_B4:
+        case ARM64_REG_H4:
+        case ARM64_REG_W4:
+        case ARM64_REG_X4:
+                return ctx->x[4];
+        case ARM64_REG_B5:
+        case ARM64_REG_H5:
+        case ARM64_REG_W5:
+        case ARM64_REG_X5:
+                return ctx->x[5];
+        case ARM64_REG_B6:
+        case ARM64_REG_H6:
+        case ARM64_REG_W6:
+        case ARM64_REG_X6:
+                return ctx->x[6];
+        case ARM64_REG_B7:
+        case ARM64_REG_H7:
+        case ARM64_REG_W7:
+        case ARM64_REG_X7:
+                return ctx->x[7];
+        case ARM64_REG_B8:
+        case ARM64_REG_H8:
+        case ARM64_REG_W8:
+        case ARM64_REG_X8:
+                return ctx->x[8];
+        case ARM64_REG_B9:
+        case ARM64_REG_H9:
+        case ARM64_REG_W9:
+        case ARM64_REG_X9:
+                return ctx->x[9];
+        case ARM64_REG_B10:
+        case ARM64_REG_H10:
+        case ARM64_REG_W10:
+        case ARM64_REG_X10:
+                return ctx->x[10];
+        case ARM64_REG_B11:
+        case ARM64_REG_H11:
+        case ARM64_REG_W11:
+        case ARM64_REG_X11:
+                return ctx->x[11];
+        case ARM64_REG_B12:
+        case ARM64_REG_H12:
+        case ARM64_REG_W12:
+        case ARM64_REG_X12:
+                return ctx->x[12];
+        case ARM64_REG_B13:
+        case ARM64_REG_H13:
+        case ARM64_REG_W13:
+        case ARM64_REG_X13:
+                return ctx->x[13];
+        case ARM64_REG_B14:
+        case ARM64_REG_H14:
+        case ARM64_REG_W14:
+        case ARM64_REG_X14:
+                return ctx->x[14];
+        case ARM64_REG_B15:
+        case ARM64_REG_H15:
+        case ARM64_REG_W15:
+        case ARM64_REG_X15:
+                return ctx->x[15];
+        case ARM64_REG_B16:
+        case ARM64_REG_H16:
+        case ARM64_REG_W16:
+        case ARM64_REG_X16:
+                return ctx->x[16];
+        case ARM64_REG_B17:
+        case ARM64_REG_H17:
+        case ARM64_REG_W17:
+        case ARM64_REG_X17:
+                return ctx->x[17];
+        case ARM64_REG_B18:
+        case ARM64_REG_H18:
+        case ARM64_REG_W18:
+        case ARM64_REG_X18:
+                return ctx->x[18];
+        case ARM64_REG_B19:
+        case ARM64_REG_H19:
+        case ARM64_REG_W19:
+        case ARM64_REG_X19:
+                return ctx->x[19];
+        case ARM64_REG_B20:
+        case ARM64_REG_H20:
+        case ARM64_REG_W20:
+        case ARM64_REG_X20:
+                return ctx->x[20];
+        case ARM64_REG_B21:
+        case ARM64_REG_H21:
+        case ARM64_REG_W21:
+        case ARM64_REG_X21:
+                return ctx->x[21];
+        case ARM64_REG_B22:
+        case ARM64_REG_H22:
+        case ARM64_REG_W22:
+        case ARM64_REG_X22:
+                return ctx->x[22];
+        case ARM64_REG_B23:
+        case ARM64_REG_H23:
+        case ARM64_REG_W23:
+        case ARM64_REG_X23:
+                return ctx->x[23];
+        case ARM64_REG_B24:
+        case ARM64_REG_H24:
+        case ARM64_REG_W24:
+        case ARM64_REG_X24:
+                return ctx->x[24];
+        case ARM64_REG_B25:
+        case ARM64_REG_H25:
+        case ARM64_REG_W25:
+        case ARM64_REG_X25:
+                return ctx->x[25];
+        case ARM64_REG_B26:
+        case ARM64_REG_H26:
+        case ARM64_REG_W26:
+        case ARM64_REG_X26:
+                return ctx->x[26];
+        case ARM64_REG_B27:
+        case ARM64_REG_H27:
+        case ARM64_REG_W27:
+        case ARM64_REG_X27:
+                return ctx->x[27];
+        case ARM64_REG_B28:
+        case ARM64_REG_H28:
+        case ARM64_REG_W28:
+        case ARM64_REG_X28:
+                return ctx->x[28];
+        case ARM64_REG_FP:
+                return ctx->fp;
+        case ARM64_REG_LR:
+                return ctx->lr;
+        default:
+                return 0;
+        }
+
+}
+
+static inline void print_trace_line(GumCpuContext *cpu_ctx, arm64_reg reg)
+{
+        const gchar *r_name = reg_name(reg);
+        if (r_name)
+        {
+                guint64 r_val = ctx_reg_read(cpu_ctx, reg);
+                g_string_append_printf(state->trace, ",%s=0x%zx", r_name, r_val);
+        }
+        
+}
+
+static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, arm64_reg reg)
+{
+        const gchar *r_name = reg_name(reg);
+        if (r_name)
+        {
+                guint64 r_val = ctx_reg_read(cpu_ctx, reg);
+                bool ok = r_val != ctx_reg_read(state->old_cpu_ctx, reg);
+                if(ok)g_string_append_printf(state->trace, ",%s=0x%zx", r_name, r_val);
+        }
+}
+
+static void
+on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
+{
+        const struct ctx_insn *ctx_insn = user_data;
+        struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
+        struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
+        gsize i, j;
+
+        /* trace generation phase */
+
+        if (last_ctx_trace->init) {
+                if(last_ctx_insn->enable_regs)
+                {
+                        g_string_append_printf(state->trace, ",pc=0x%zx", last_ctx_trace->pc);
+
+                        if(state->dump_all_regs)
+                        {
+                                arm64_reg reg;
+                                for (reg = ARM64_REG_X0; reg < ARM64_REG_X28+1; ++reg) {
+                                        print_trace_line_cmp(cpu_ctx, reg);
+                                }
+                                print_trace_line_cmp(cpu_ctx, ARM64_REG_FP);
+                                print_trace_line_cmp(cpu_ctx, ARM64_REG_SP);
+                                print_trace_line_cmp(cpu_ctx, ARM64_REG_LR);
+                                state->dump_all_regs = 0;
+                        }
+                        else
+                        {
+                                for (i = 0; i < last_ctx_insn->n_regs; ++i) {
+                                        arm64_reg reg = last_ctx_insn->regs[i];
+                                        print_trace_line(cpu_ctx, reg);
+                                }
+                        }
+                }
+
+
+                for (i = 0; i < last_ctx_insn->n_mems; ++i) {
+                        const struct ctx_insn_mem *mem = &last_ctx_insn->mems[i];
+
+                        /* capstone memory operand read access is wrong */
+                        g_string_append_printf(state->trace, ",m%s=0x%zx:",
+                                               (mem->ac & state->mflag) ? "w" : "r",
+                                               (guint64)mem->ptr);
+
+                        for (j = 0; j < mem->size; ++j)
+                                g_string_append_printf(state->trace, "%02x",
+                                                       mem->ptr[j] & 0xff);
+                }
+
+                if(last_ctx_insn->enable_regs)g_string_append_c(state->trace, '\n');
+        }
+
+        /* trace context phase */
+        if(state->dump_all_regs<2)
+        {
+                if(!ctx_insn->enable_regs) 
+                {
+                        state->dump_all_regs = 2;
+                        memcpy(state->old_cpu_ctx, cpu_ctx, sizeof(GumCpuContext));
+                }
+
+                else
+                {
+                        state->dump_all_regs = ctx_insn->call_instruction;
+                        if(state->dump_all_regs)
+                        {
+                                memcpy(state->old_cpu_ctx, cpu_ctx, sizeof(GumCpuContext));
+                        }
+                }
+        }
+
+        last_ctx_trace->pc = cpu_ctx->pc;
+
+        memcpy(last_ctx_insn->regs, ctx_insn->regs,
+               ctx_insn->n_regs * sizeof(arm64_reg));
+        last_ctx_insn->n_regs = ctx_insn->n_regs;
+
+        last_ctx_insn->enable_regs = ctx_insn->enable_regs;
+        last_ctx_trace->init = TRUE;
+
+        
+
+        for (i = 0; i < ctx_insn->n_mems; ++i) {
+                const struct ctx_insn_mem *mem = &ctx_insn->mems[i];
+                const arm64_op_mem *mem_op = &mem->op;
+                struct ctx_insn_mem *last_mem = &last_ctx_insn->mems[i];
+                gsize r_size;
+                guint64 r_val;
+
+                memcpy(last_mem, mem, sizeof(*last_mem));
+
+                last_mem->ptr = 0;
+                if (mem_op->base != ARM64_REG_INVALID) {
+                        r_size = reg_size(mem_op->base);
+                        r_val = ctx_reg_read(cpu_ctx, mem_op->base);
+                        if ((r_size > 0) && (r_size < sizeof(guint64)))
+                                last_mem->ptr += (r_val & ((1 << (8 * r_size)) - 1));
+                        else
+                                last_mem->ptr += r_val;
+                }
+                if (mem_op->index != ARM64_REG_INVALID) {
+                        r_size = reg_size(mem_op->index);
+                        r_val = ctx_reg_read(cpu_ctx, mem_op->index);
+                        if ((r_size > 0) && (r_size < sizeof(guint64)))
+                                last_mem->ptr += (r_val & ((1 << (8 * r_size)) - 1));
+                        else
+                                last_mem->ptr += r_val;
+                }
+                last_mem->ptr += mem_op->disp;
+        }
+        last_ctx_insn->n_mems = ctx_insn->n_mems;
+
+        /* trace flush phase */
+
+        if (state->trace->len >= TRACE_FLUSH_SIZE)
+                flush();
+
+        #ifdef END_ADDR
+                if (cpu_ctx->pc == END_ADDR)
+                {
+                        flush();
+                        send_end();
+                }
+        #endif
+        #ifdef TRACE_ADDR
+                if (cpu_ctx->pc == TRACE_ADDR)
+                {
+                        flush();
+                }
+        #endif
+
+}
+
+
+void
+init(void)
+{
+        state = g_malloc0(sizeof(*state));
+        state->old_cpu_ctx = g_malloc0(sizeof(GumCpuContext));
+        memset((void*)state->old_cpu_ctx, 0, sizeof(GumCpuContext));
+        state->trace = g_string_new(NULL);
+        state->dump_all_regs = 2;
+        state->exclude = exclude();
+        state->needmem = needmem();
+        if(swap_rw())state->mflag = CS_AC_READ;
+        else state->mflag = CS_AC_WRITE;
+}
+
+void
+finalize(void)
+{
+        g_string_free(state->trace, TRUE);
+        g_free(state);
+}
+
+void
+flush(void)
+{
+        gchar *trace = g_string_free(state->trace, FALSE);
+
+        send(trace);
+        g_free(trace);
+        state->trace = g_string_new(NULL);
+}
+
+void
+transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
+          gpointer user_data)
+{
+        cs_insn *insn;
+        gsize insn_cnt = 0;
+        gboolean enable_regs;
+        gboolean enable_mem;
+        enable_regs = true;
+        enable_mem = state->needmem;
+        while (gum_stalker_iterator_next(iterator, &insn)) {
+                cs_arm64 *insn_arm64;
+                struct ctx_insn *ctx_insn;
+                gsize i;
+
+                if (insn_cnt == 0)
+                {
+                        if (filter(insn->address)) {
+                                if(state->exclude)
+                                {
+                                        gum_stalker_iterator_keep(iterator);
+                                        continue;
+                                }
+                                else
+                                {
+                                        enable_regs = false;
+                                }  
+                        }
+                }
+                
+                
+                insn_arm64 = &(insn->detail->arm64);
+
+                ctx_insn = g_malloc(sizeof(struct ctx_insn));
+                ctx_insn->n_regs = 0;
+                ctx_insn->n_mems = 0;
+
+                for (i = 0; i < insn_arm64->op_count; ++i) {
+                        cs_arm64_op *op = &insn_arm64->operands[i];
+
+                        switch (op->type) {
+                        case ARM64_OP_REG:
+                                if (enable_regs && op->access & CS_AC_WRITE)
+                                        ctx_insn->regs[ctx_insn->n_regs++] = op->reg;
+                                break;
+                        case ARM64_OP_MEM:
+                                if(!enable_mem)break;
+
+                                ctx_insn->mems[ctx_insn->n_mems].op = op->mem;
+                                ctx_insn->mems[ctx_insn->n_mems].ac = op->access;
+                                ctx_insn->mems[ctx_insn->n_mems].size = mem_size(insn, &(insn_arm64->operands[0]));
+                                ++ctx_insn->n_mems;
+                                break;
+                        default:
+                                break;
+                        }
+                }
+                ctx_insn->call_instruction=0;
+                ctx_insn->enable_regs = enable_regs;
+                //if(insn->detail->groups[1] || insn->detail->groups[2] || insn->detail->groups[4] // ARM64_GRP_JMP|CALL|INT (does not work for BR?)
+                if(insn->id == ARM64_INS_BR || insn->id == ARM64_INS_BLR) //Check if exhaustive for branchs outside of program
+                {
+                        ctx_insn->call_instruction=1; 
+                }
+                gum_stalker_iterator_put_callout(iterator, on_insn, ctx_insn, g_free);
+                gum_stalker_iterator_keep(iterator);
+                ++insn_cnt;
+        }
+}
+

--- a/tracer/frida/trace_x64.c
+++ b/tracer/frida/trace_x64.c
@@ -1,0 +1,610 @@
+#include <capstone.h>
+#include <glib.h>
+#include <gum/gumstalker.h>
+#include <string.h>
+
+
+#define TRACE_FLUSH_SIZE        (1 << 20)
+
+#define CTX_INSN_REGS_MAX       32
+#define CTX_INSN_MEMS_MAX       2
+
+
+struct ctx_insn_mem {
+        x86_op_mem      op;             /* operand */
+        cs_ac_type      ac;             /* access type */
+        gsize           size;           /* access size */
+        const guint8    *ptr;           /* resolved pointer */
+        gboolean         stackreg;      /* stack register for push/pop */
+};
+
+struct ctx_insn {
+        x86_reg                 regs[CTX_INSN_REGS_MAX];
+        gsize                   n_regs;
+        struct ctx_insn_mem     mems[CTX_INSN_MEMS_MAX];
+        gsize                   n_mems;
+        char call_instruction;
+        bool enable_regs;
+};
+
+struct ctx_trace {
+        gboolean init;
+        guint64 rip;
+        struct ctx_insn ctx_insn;
+};
+
+struct state {
+        struct ctx_trace last_ctx_trace;
+        GString *trace;
+        GumCpuContext *old_cpu_ctx;
+        char dump_all_regs;
+        bool exclude;
+        bool needmem;
+};
+
+
+extern struct state *state;
+extern int filter(guintptr addr);
+extern bool exclude();
+extern bool needmem();
+extern char swap_rw();
+extern void send(gchar *str);
+
+
+void init(void);
+void finalize(void);
+void flush(void);
+void send_end(void);
+void transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
+               gpointer user_data);
+
+
+static gsize
+reg_size(x86_reg reg)
+{
+        switch (reg) {
+        case X86_REG_AL:
+        case X86_REG_BL:
+        case X86_REG_CL:
+        case X86_REG_DL:
+        case X86_REG_SPL:
+        case X86_REG_BPL:
+        case X86_REG_SIL:
+        case X86_REG_DIL:
+        case X86_REG_R8B:
+        case X86_REG_R9B:
+        case X86_REG_R10B:
+        case X86_REG_R11B:
+        case X86_REG_R12B:
+        case X86_REG_R13B:
+        case X86_REG_R14B:
+        case X86_REG_R15B:
+        case X86_REG_AH:
+        case X86_REG_BH:
+        case X86_REG_CH:
+        case X86_REG_DH:
+                return 1;
+        case X86_REG_AX:
+        case X86_REG_BX:
+        case X86_REG_CX:
+        case X86_REG_DX:
+        case X86_REG_SP:
+        case X86_REG_BP:
+        case X86_REG_SI:
+        case X86_REG_DI:
+        case X86_REG_R8W:
+        case X86_REG_R9W:
+        case X86_REG_R10W:
+        case X86_REG_R11W:
+        case X86_REG_R12W:
+        case X86_REG_R13W:
+        case X86_REG_R14W:
+        case X86_REG_R15W:
+                return 2;
+        case X86_REG_EAX:
+        case X86_REG_EBX:
+        case X86_REG_ECX:
+        case X86_REG_EDX:
+        case X86_REG_ESP:
+        case X86_REG_EBP:
+        case X86_REG_ESI:
+        case X86_REG_EDI:
+        case X86_REG_R8D:
+        case X86_REG_R9D:
+        case X86_REG_R10D:
+        case X86_REG_R11D:
+        case X86_REG_R12D:
+        case X86_REG_R13D:
+        case X86_REG_R14D:
+        case X86_REG_R15D:
+                return 4;
+        default:
+                return 8;
+        }
+}
+
+static const gchar *
+reg_name(x86_reg reg)
+{
+        switch (reg) {
+        case X86_REG_AL:
+        case X86_REG_AH:
+        case X86_REG_AX:
+        case X86_REG_EAX:
+        case X86_REG_RAX:
+                return "rax";
+        case X86_REG_BL:
+        case X86_REG_BH:
+        case X86_REG_BX:
+        case X86_REG_EBX:
+        case X86_REG_RBX:
+                return "rbx";
+        case X86_REG_CL:
+        case X86_REG_CH:
+        case X86_REG_CX:
+        case X86_REG_ECX:
+        case X86_REG_RCX:
+                return "rcx";
+        case X86_REG_DL:
+        case X86_REG_DH:
+        case X86_REG_DX:
+        case X86_REG_EDX:
+        case X86_REG_RDX:
+                return "rdx";
+        case X86_REG_SPL:
+        case X86_REG_SP:
+        case X86_REG_ESP:
+        case X86_REG_RSP:
+                return "rsp";
+        case X86_REG_BPL:
+        case X86_REG_BP:
+        case X86_REG_EBP:
+        case X86_REG_RBP:
+                return "rbp";
+        case X86_REG_SIL:
+        case X86_REG_SI:
+        case X86_REG_ESI:
+        case X86_REG_RSI:
+                return "rsi";
+        case X86_REG_DIL:
+        case X86_REG_DI:
+        case X86_REG_EDI:
+        case X86_REG_RDI:
+                return "rdi";
+        case X86_REG_R8B:
+        case X86_REG_R8W:
+        case X86_REG_R8D:
+        case X86_REG_R8:
+                return "r8";
+        case X86_REG_R9B:
+        case X86_REG_R9W:
+        case X86_REG_R9D:
+        case X86_REG_R9:
+                return "r9";
+        case X86_REG_R10B:
+        case X86_REG_R10W:
+        case X86_REG_R10D:
+        case X86_REG_R10:
+                return "r10";
+        case X86_REG_R11B:
+        case X86_REG_R11W:
+        case X86_REG_R11D:
+        case X86_REG_R11:
+                return "r11";
+        case X86_REG_R12B:
+        case X86_REG_R12W:
+        case X86_REG_R12D:
+        case X86_REG_R12:
+                return "r12";
+        case X86_REG_R13B:
+        case X86_REG_R13W:
+        case X86_REG_R13D:
+        case X86_REG_R13:
+                return "r13";
+        case X86_REG_R14B:
+        case X86_REG_R14W:
+        case X86_REG_R14D:
+        case X86_REG_R14:
+                return "r14";
+        case X86_REG_R15B:
+        case X86_REG_R15W:
+        case X86_REG_R15D:
+        case X86_REG_R15:
+                return "r15";
+        default:
+                return NULL;
+        }
+}
+
+static guint64
+ctx_reg_read(const GumCpuContext *ctx, x86_reg reg)
+{
+        switch (reg) {
+        case X86_REG_AL:
+        case X86_REG_AH:
+        case X86_REG_AX:
+        case X86_REG_EAX:
+        case X86_REG_RAX:
+                return ctx->rax;
+        case X86_REG_BL:
+        case X86_REG_BH:
+        case X86_REG_BX:
+        case X86_REG_EBX:
+        case X86_REG_RBX:
+                return ctx->rbx;
+        case X86_REG_CL:
+        case X86_REG_CH:
+        case X86_REG_CX:
+        case X86_REG_ECX:
+        case X86_REG_RCX:
+                return ctx->rcx;
+        case X86_REG_DL:
+        case X86_REG_DH:
+        case X86_REG_DX:
+        case X86_REG_EDX:
+        case X86_REG_RDX:
+                return ctx->rdx;
+        case X86_REG_SPL:
+        case X86_REG_SP:
+        case X86_REG_ESP:
+        case X86_REG_RSP:
+                return ctx->rsp;
+        case X86_REG_BPL:
+        case X86_REG_BP:
+        case X86_REG_EBP:
+        case X86_REG_RBP:
+                return ctx->rbp;
+        case X86_REG_SIL:
+        case X86_REG_SI:
+        case X86_REG_ESI:
+        case X86_REG_RSI:
+                return ctx->rsi;
+        case X86_REG_DIL:
+        case X86_REG_DI:
+        case X86_REG_EDI:
+        case X86_REG_RDI:
+                return ctx->rdi;
+        case X86_REG_R8B:
+        case X86_REG_R8W:
+        case X86_REG_R8D:
+        case X86_REG_R8:
+                return ctx->r8;
+        case X86_REG_R9B:
+        case X86_REG_R9W:
+        case X86_REG_R9D:
+        case X86_REG_R9:
+                return ctx->r9;
+        case X86_REG_R10B:
+        case X86_REG_R10W:
+        case X86_REG_R10D:
+        case X86_REG_R10:
+                return ctx->r10;
+        case X86_REG_R11B:
+        case X86_REG_R11W:
+        case X86_REG_R11D:
+        case X86_REG_R11:
+                return ctx->r11;
+        case X86_REG_R12B:
+        case X86_REG_R12W:
+        case X86_REG_R12D:
+        case X86_REG_R12:
+                return ctx->r12;
+        case X86_REG_R13B:
+        case X86_REG_R13W:
+        case X86_REG_R13D:
+        case X86_REG_R13:
+                return ctx->r13;
+        case X86_REG_R14B:
+        case X86_REG_R14W:
+        case X86_REG_R14D:
+        case X86_REG_R14:
+                return ctx->r14;
+        case X86_REG_R15B:
+        case X86_REG_R15W:
+        case X86_REG_R15D:
+        case X86_REG_R15:
+                return ctx->r15;
+        /* handle x86 cs segment */
+        case X86_REG_RIP:
+                return ctx->rip;
+        default:
+                return 0;
+        }
+
+}
+
+static inline void print_trace_line(GumCpuContext *cpu_ctx, x86_reg reg)
+{
+        const gchar *r_name = reg_name(reg);
+        if (r_name)
+        {
+                guint64 r_val = ctx_reg_read(cpu_ctx, reg);
+                g_string_append_printf(state->trace, ",%s=0x%zx", r_name, r_val);
+        }
+}
+
+static inline void print_trace_line_cmp(GumCpuContext *cpu_ctx, x86_reg reg)
+{
+        const gchar *r_name = reg_name(reg);
+        if (r_name)
+        {
+                guint64 r_val = ctx_reg_read(cpu_ctx, reg);
+                bool ok = r_val != ctx_reg_read(state->old_cpu_ctx, reg);
+                if(ok)g_string_append_printf(state->trace, ",%s=0x%zx", r_name, r_val);
+        }
+}
+
+static void
+on_insn(GumCpuContext *cpu_ctx, gpointer user_data)
+{
+        const struct ctx_insn *ctx_insn = user_data;
+        struct ctx_trace *last_ctx_trace = &state->last_ctx_trace;
+        struct ctx_insn *last_ctx_insn = &last_ctx_trace->ctx_insn;
+        gsize i, j;
+
+        /* trace generation phase */
+
+        if (last_ctx_trace->init) {
+                if(last_ctx_insn->enable_regs)
+                {
+                        g_string_append_printf(state->trace, ",rip=0x%zx", last_ctx_trace->rip);
+
+                        if(state->dump_all_regs)
+                        {
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RAX);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RBX);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RCX);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RDX);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RSP);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RBP);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RSI);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_RDI);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R8);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R9);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R10);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R11);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R12);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R13);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R14);
+                                print_trace_line_cmp(cpu_ctx, X86_REG_R15);
+                                state->dump_all_regs = 0;
+                        }
+                        else
+                        {
+                                for (i = 0; i < last_ctx_insn->n_regs; ++i) {
+                                        x86_reg reg = last_ctx_insn->regs[i];
+                                        print_trace_line(cpu_ctx, reg);
+                                }
+                        }
+                }
+
+
+                for (i = 0; i < last_ctx_insn->n_mems; ++i) {
+                        const struct ctx_insn_mem *mem = &last_ctx_insn->mems[i];
+
+                        /* capstone memory operand read access is wrong */
+                        g_string_append_printf(state->trace, ",m%s=0x%zx:",
+                                               (mem->ac & CS_AC_WRITE) ? "w" : "r",
+                                               (guint64)mem->ptr);
+
+                        for (j = 0; j < mem->size; ++j)
+                               g_string_append_printf(state->trace, "%02x",
+                                                      mem->ptr[j] & 0xff);
+                }
+
+                if(last_ctx_insn->enable_regs)g_string_append_c(state->trace, '\n');
+        }
+
+        /* trace context phase */
+        if(state->dump_all_regs<2)
+        {
+                if(!ctx_insn->enable_regs) 
+                {
+                        state->dump_all_regs = 2;
+                        memcpy(state->old_cpu_ctx, cpu_ctx, sizeof(GumCpuContext));
+                }
+
+                else
+                {
+                        state->dump_all_regs = ctx_insn->call_instruction;
+                        if(state->dump_all_regs)
+                        {
+                                memcpy(state->old_cpu_ctx, cpu_ctx, sizeof(GumCpuContext));
+                        }
+                }
+        }
+
+        last_ctx_trace->rip = cpu_ctx->rip;
+
+        memcpy(last_ctx_insn->regs, ctx_insn->regs,
+               ctx_insn->n_regs * sizeof(x86_reg));
+        last_ctx_insn->n_regs = ctx_insn->n_regs;
+
+        last_ctx_insn->enable_regs = ctx_insn->enable_regs;
+        last_ctx_trace->init = TRUE;
+
+        for (i = 0; i < ctx_insn->n_mems; ++i) {
+                const struct ctx_insn_mem *mem = &ctx_insn->mems[i];
+                const x86_op_mem *mem_op = &mem->op;
+                struct ctx_insn_mem *last_mem = &last_ctx_insn->mems[i];
+                guint64 r_val;
+
+                memcpy(last_mem, mem, sizeof(*last_mem));
+
+                last_mem->ptr = 0;
+                if (mem->stackreg) {
+                        last_mem->ptr += ctx_reg_read(cpu_ctx, X86_REG_RSP);
+                        if (mem->ac & CS_AC_WRITE)
+                                /* TODO: operand size */
+                                last_mem->ptr -= 0x8;
+                } else {
+                        if (mem_op->base != X86_REG_INVALID) {
+                                r_val = ctx_reg_read(cpu_ctx, mem_op->base);
+                                last_mem->ptr += r_val;
+                        }
+                        if (mem_op->index != X86_REG_INVALID) {
+                                r_val = ctx_reg_read(cpu_ctx, mem_op->index);
+                                last_mem->ptr += mem_op->scale * r_val;
+                        }
+                        last_mem->ptr += mem_op->disp;
+                }
+        }
+        last_ctx_insn->n_mems = ctx_insn->n_mems;
+
+        /* trace flush phase */
+
+        if (state->trace->len >= TRACE_FLUSH_SIZE)
+                flush();
+
+        #ifdef END_ADDR
+                if (cpu_ctx->rip == END_ADDR)
+                {
+                        flush();
+                        send_end();
+                }
+        #endif
+
+        #ifdef TRACE_ADDR
+                if (cpu_ctx->rip == TRACE_ADDR)
+                {
+                        flush();
+                }
+        #endif
+
+}
+
+
+void
+init(void)
+{
+        state = g_malloc0(sizeof(*state));
+        state->old_cpu_ctx = g_malloc0(sizeof(GumCpuContext));
+        memset((void*)state->old_cpu_ctx, 0, sizeof(GumCpuContext));
+        state->trace = g_string_new(NULL);
+        state->dump_all_regs = 2;
+        state->exclude = exclude();
+        state->needmem = needmem();
+}
+
+void
+finalize(void)
+{
+        g_string_free(state->trace, TRUE);
+        g_free(state);
+}
+
+void
+flush(void)
+{
+        gchar *trace = g_string_free(state->trace, FALSE);
+
+        send(trace);
+        g_free(trace);
+        state->trace = g_string_new(NULL);
+}
+
+void
+transform(GumStalkerIterator *iterator, GumStalkerOutput *output,
+          gpointer user_data)
+{
+        cs_insn *insn;
+        gsize insn_cnt = 0;
+        gboolean enable_regs;
+        gboolean enable_mem;
+        enable_regs = true;
+        enable_mem = state->needmem;
+        while (gum_stalker_iterator_next(iterator, &insn)) {
+                cs_x86 *insn_x86;
+                struct ctx_insn *ctx_insn;
+                gsize i;
+
+                if (insn_cnt == 0)
+                {
+                        if (filter(insn->address)) {
+                                if(state->exclude)
+                                {
+                                        gum_stalker_iterator_keep(iterator);
+                                        continue;
+                                }
+                                else
+                                {
+                                        enable_regs = false;
+                                }
+                        }
+                }
+
+                insn_x86 = &(insn->detail->x86);
+
+                ctx_insn = g_malloc(sizeof(struct ctx_insn));
+                ctx_insn->n_regs = 0;
+                ctx_insn->n_mems = 0;
+
+                if ((insn->id == X86_INS_PUSH) || (insn->id == X86_INS_POP)) {
+                        cs_x86_op *op = &insn_x86->operands[0];
+
+                        ctx_insn->regs[ctx_insn->n_regs++] = X86_REG_RSP;
+
+                        /* TODO: push immediate */
+                        if (op->type == X86_OP_REG) {
+                                if (op->access & CS_AC_READ)
+                                        ctx_insn->mems[ctx_insn->n_mems].ac = CS_AC_WRITE;
+                                else
+                                        ctx_insn->mems[ctx_insn->n_mems].ac = CS_AC_READ;
+                                ctx_insn->mems[ctx_insn->n_mems].size = op->size;
+                                ctx_insn->mems[ctx_insn->n_mems].stackreg = 1;
+                                ++ctx_insn->n_mems;
+                        }
+                }
+
+                for (i = 0; i < insn_x86->op_count; ++i) {
+                        cs_x86_op *op = &insn_x86->operands[i];
+
+                        switch (op->type) {
+                        case X86_OP_REG:
+                                if (!enable_regs)
+                                        break;
+                                if (op->access & CS_AC_WRITE)
+                                        ctx_insn->regs[ctx_insn->n_regs++] = op->reg;
+                                break;
+                        case X86_OP_MEM:
+                                if(!enable_mem)break;
+                                
+                                /* TODO: lea */
+                                if (insn->id == X86_INS_LEA)
+                                        break;
+                                /* ignore awful n-bytes nop */
+                                if (insn->id == X86_INS_NOP)
+                                        break;
+                                /* TODO: x86 segments */
+                                if (op->mem.segment != X86_REG_INVALID)
+                                        break;
+                                ctx_insn->mems[ctx_insn->n_mems].op = op->mem;
+                                if (op->mem.base == X86_REG_RIP || op->mem.base == X86_REG_EIP) {
+                                        ctx_insn->mems[ctx_insn->n_mems].op.disp += insn->size;
+                                }
+                                ctx_insn->mems[ctx_insn->n_mems].ac = op->access;
+                                ctx_insn->mems[ctx_insn->n_mems].size = op->size;
+                                ctx_insn->mems[ctx_insn->n_mems].stackreg = 0;
+                                ++ctx_insn->n_mems;
+                                
+                                break;
+                        default:
+                                break;
+                        }
+                }
+                ctx_insn->call_instruction=0;
+                ctx_insn->enable_regs = enable_regs;
+                //if(insn->detail->groups[1] || insn->detail->groups[2] || insn->detail->groups[4] // ARM64_GRP_JMP|CALL|INT (does not work for BR?)
+                // TODO
+                /*
+                if(insn->id == ARM64_INS_BR || insn->id == ARM64_INS_BLR) //Check if exhaustive for branchs outside of program
+                {
+                        ctx_insn->call_instruction=1; 
+                }
+                */
+                gum_stalker_iterator_put_callout(iterator, on_insn, ctx_insn, g_free);
+                gum_stalker_iterator_keep(iterator);
+                ++insn_cnt;
+        }
+}
+

--- a/tracer/frida/utils.py
+++ b/tracer/frida/utils.py
@@ -1,0 +1,41 @@
+import sys
+import bisect
+
+def print_lib_usage(trace_path, mappings_path):
+
+    trace = open(trace_path,"r").read()
+    mappings = open(mappings_path,"r").read()
+
+    maps = []
+    for line in mappings.split('\n'):
+        if len(line)>1:
+            name, start, end = line.split(" ")
+            maps.append([int(start, 0), int(end, 0), name, 0])
+    maps.sort()
+    results = set()
+    tot = 0
+    for line in trace.split("\n"):
+        line = line.replace("rip=", "pc=").replace("eip=", "pc=")
+        if "pc=" in line:
+            line = line.split("pc=")[1]
+            line = line.split(",")[0]
+            pc = int(line, 0)
+            idx = bisect.bisect_left(maps, [pc, 0, "", 0])
+            if idx > 0 and pc < maps[idx-1][1]:
+                results.add(idx-1)
+                maps[idx-1][3]+=1
+            tot+=1
+
+    last_table = []
+    for idx in results:
+        percent = 100*maps[idx][3]/tot
+        last_table.append((percent, maps[idx][2]))
+
+    last_table.sort()
+    last_table = last_table[::-1]
+
+    print("-------------")
+    print("Libs breakdown for this trace :\n")
+    for t in last_table:
+        print(t[1]+(" (%.2f" % (t[0]))+"%)")
+    print("-------------\n")


### PR DESCRIPTION
## Summary
- remove the extra ASLR slide header line so Frida traces match existing Tenet text trace format
- update tracer documentation to describe the simplified header that aligns with current traces

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69316d65b2a883289f15d90f1b5e45de)